### PR TITLE
use axios for bug updates. Fix sort only working once. Truncate desc. Allow table to expand to page width.

### DIFF
--- a/components/bugTable/BugTable.js
+++ b/components/bugTable/BugTable.js
@@ -90,8 +90,9 @@ export default function BugTable() {
         setSortedBugs(bugs);
     };
 
-    const handleSort = (field, direction = sortDirection, list = bugs) => {
+    const handleSort = (field, direction = null, list = bugs) => {
         const newDirection = direction || (sortField === field && sortDirection === 'asc' ? 'desc' : 'asc');
+
         setSortField(field);
         setSortDirection(newDirection);
 

--- a/components/bugTable/BugTableRow.js
+++ b/components/bugTable/BugTableRow.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { TableRow, TableCell, IconButton, TextField, Select, MenuItem } from '@mui/material';
+import { TableRow, TableCell, IconButton, TextField, Select, MenuItem, Typography } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
 import CheckIcon from '@mui/icons-material/Check';
@@ -58,13 +58,7 @@ export default function BugTableRow({ bug, onEdit, onDelete }) {
             <TableRow>
                 {isEditing ? (
                     <>
-                        <TableCell>
-                            <TextField
-                                value={editedBug['Bug ID']}
-                                disabled
-                                fullWidth
-                            />
-                        </TableCell>
+                        <TableCell>{bug.fields['Bug ID']}</TableCell>
                         <TableCell>
                             <TextField
                                 value={editedBug.Title}
@@ -117,7 +111,20 @@ export default function BugTableRow({ bug, onEdit, onDelete }) {
                     <>
                         <TableCell>{bug.fields['Bug ID']}</TableCell>
                         <TableCell>{bug.fields.Title}</TableCell>
-                        <TableCell>{bug.fields.Description}</TableCell>
+                        <TableCell>
+                            <Typography
+                                noWrap
+                                title={bug.fields.Description} // Tooltip to show the full description on hover
+                                sx={{
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    whiteSpace: 'nowrap',
+                                    maxWidth: '200px', // Adjust the width as needed
+                                }}
+                            >
+                                {bug.fields.Description}
+                            </Typography>
+                        </TableCell>
                         <TableCell>{bug.fields['Reported Date']}</TableCell>
                         <TableCell>{bug.fields.Status}</TableCell>
                         <TableCell>{bug.fields.Severity}</TableCell>

--- a/components/bugTable/BugTableRow.js
+++ b/components/bugTable/BugTableRow.js
@@ -114,12 +114,12 @@ export default function BugTableRow({ bug, onEdit, onDelete }) {
                         <TableCell>
                             <Typography
                                 noWrap
-                                title={bug.fields.Description} // Tooltip to show the full description on hover
+                                title={bug.fields.Description}
                                 sx={{
                                     overflow: 'hidden',
                                     textOverflow: 'ellipsis',
                                     whiteSpace: 'nowrap',
-                                    maxWidth: '200px', // Adjust the width as needed
+                                    maxWidth: '20vw',
                                 }}
                             >
                                 {bug.fields.Description}

--- a/pages/api/bugs/[id].js
+++ b/pages/api/bugs/[id].js
@@ -1,4 +1,5 @@
 import { table } from '../airtable';
+import axios from 'axios';
 
 export default async function handler(req, res) {
     const { id } = req.query;
@@ -13,8 +14,28 @@ export default async function handler(req, res) {
             if (!fields) {
                 return res.status(400).json({ error: 'Fields are required for updating.' });
             }
-            const updatedRecord = await table.update(id, fields);
-            return res.status(200).json({ record: updatedRecord });
+
+            const airtableApiUrl = `https://api.airtable.com/v0/appiN5YQubFNexMWb/Bugs`;
+            const airtableApiKey = process.env.AIRTABLE_API_KEY;
+            const response = await axios.patch(
+                airtableApiUrl,
+                {
+                    records: [
+                        {
+                            id: id,
+                            fields: fields,
+                        },
+                    ],
+                },
+                {
+                    headers: {
+                        Authorization: `Bearer ${airtableApiKey}`,
+                        'Content-Type': 'application/json',
+                    },
+                }
+            );
+
+            return res.status(200).json({ record: response.data.records[0] });
         }
 
         if (req.method === 'DELETE') {

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,7 +3,7 @@ import BugTable from '../components/bugTable';
 
 export default function Home() {
     return (
-        <Container>
+        <Container maxWidth={false} sx={{ width: '100%' }}>
             <Typography variant="h4" gutterBottom>Bug Tracker</Typography>
             <BugTable />
         </Container>


### PR DESCRIPTION
Time elapsed: ~20 minutes

Changes: 
Use axios http library for bug update api calls (per project requirements, must be used once). 
Allow container for content to expand to full page width. 
Fix bug in sorting where you could only sort once (clicking the same column header would not change sort direction). 
Truncate description in table. 