### PR TITLE
keep bugs sorted when searching

### DIFF
--- a/components/bugTable/BugTable.js
+++ b/components/bugTable/BugTable.js
@@ -79,15 +79,15 @@ export default function BugTable() {
             const filtered = bugs.filter((bug) =>
                 bug.fields.Title && bug.fields.Title.toLowerCase().includes(value.toLowerCase())
             );
-            setSortedBugs(filtered);
+            handleSort(sortField, sortDirection, filtered);
         } else {
-            setSortedBugs(bugs);
+            handleSort(sortField, sortDirection, bugs);
         }
     };
 
     const handleClearSearch = () => {
         setSearch('');
-        setSortedBugs(bugs);
+        handleSort(sortField, sortDirection, bugs);
     };
 
     const handleSort = (field, direction = null, list = bugs) => {


### PR DESCRIPTION
Time elapsed: ~ 10 minutes

Changes: 

handleSort after search operations (adding text, removing all text, clicking clear search button) so that the bugs are still sorted regardless of the search state